### PR TITLE
Add auto-scaling by CPU on all envs and scheduled scaling on staging

### DIFF
--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.207"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.208"
 
   # Environmental configuration
   environment             = var.environment
@@ -51,11 +51,16 @@ module "ecs-service" {
   # Service Healthcheck configuration
 
   # Service performance and scaling configs
-  desired_task_count = var.desired_task_count
-  required_cpus      = var.required_cpus
-  required_memory    = var.required_memory
-  use_fargate        = var.use_fargate
-  fargate_subnets    = local.application_subnet_ids
+  desired_task_count                 = var.desired_task_count
+  max_task_count                     = var.max_task_count
+  required_cpus                      = var.required_cpus
+  required_memory                    = var.required_memory
+  use_fargate                        = var.use_fargate
+  fargate_subnets                    = local.application_subnet_ids
+  service_autoscale_enabled          = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
+  service_scaledown_schedule         = var.service_scaledown_schedule
+  service_scaleup_schedule           = var.service_scaleup_schedule
 
   # Service environment variable and secret configs
   task_environment = local.task_environment

--- a/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -7,6 +7,8 @@ aws_profile = "staging-eu-west-2"
 
 # scaling configs
 desired_task_count = 2 # use multi instance in staging
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"
 
 # service configs
 log_level = "trace"

--- a/groups/ecs-service/variables.tf
+++ b/groups/ecs-service/variables.tf
@@ -52,6 +52,11 @@ variable "desired_task_count" {
   description = "The desired ECS task count for this service"
   default = 1 # defaulted low for dev environments, override for production
 }
+variable "max_task_count" {
+  type        = number
+  description = "The maximum number of tasks for this service."
+  default     = 3
+}
 variable "required_cpus" {
   type = number
   description = "The required cpu resource for this service. 1024 here is 1 vCPU"
@@ -62,11 +67,30 @@ variable "required_memory" {
   description = "The required memory for this service"
   default = 512 # defaulted low for node service in dev environments, override for production
 }
-
 variable "use_fargate" {
   type        = bool
   description = "If true, sets the required capabilities for all containers in the task definition to use FARGATE, false uses EC2"
   default     = true
+}
+variable "service_autoscale_enabled" {
+  type        = bool
+  description = "Whether to enable service autoscaling, including scheduled autoscaling"
+  default     = true
+}
+variable "service_autoscale_target_value_cpu" {
+  type        = number
+  description = "Target CPU percentage for the ECS Service to autoscale on"
+  default     = 50 # 100 disables autoscaling using CPU as a metric
+}
+variable "service_scaledown_schedule" {
+  type        = string
+  description = "The schedule to use when scaling down the number of tasks to zero."
+  default     = ""
+}
+variable "service_scaleup_schedule" {
+  type        = string
+  description = "The schedule to use when scaling up the number of tasks to their normal desired level."
+  default     = ""
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a scheduled shutdown/startup on staging, and auto-scaling based on CPU on all envs.

- Configures an overnight shutdown/startup schedule for the service on staging only, so that the number of tasks is scaled to zero just before the scheduled ASG scale down happens, and scaled up to the desired count just after the ASG scale up happens.
- Enables target tracking of average CPU with a value of 50%, so if that level is exceeded the number of tasks will scale up (to max of 3) and scale down to at least 1 if CPU is below 50%.  Note that the desired number of tasks is already set at 2, so this should cause auto-scaling down to 1 task if the load is low.

Partially resolves:
https://companieshouse.atlassian.net/browse/CC-198
