### PR TITLE
Set listener priority to 5 which will give a value of 50 on the ALB

### DIFF
--- a/groups/ecs-service/locals.tf
+++ b/groups/ecs-service/locals.tf
@@ -5,7 +5,7 @@ locals {
   service_name              = "applications-developer"
   container_port            = "3000" # default node port required here until prod docker container is built allowing port change via env var
   docker_repo               = "applications.developer.web.ch.gov.uk"
-  lb_listener_rule_priority = 20
+  lb_listener_rule_priority = 5
   lb_listener_paths         = ["/manage-applications*"]
   healthcheck_path          = "/manage-applications"
   healthcheck_matcher       = "302" # no explicit healthcheck in this service yet, change this when added!


### PR DESCRIPTION
Set the priority so that the rule for "manage-applications*" (applications-developer) is evaluated before the "/*' rule (docs-developer).

Resolves:
https://companieshouse.atlassian.net/browse/CC-868