### PR TITLE
Bump ecs-service module to 1.0.215

### DIFF
--- a/groups/ecs-service/main.tf
+++ b/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.208"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.215"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
Brings in the latest ecs-module changes, including the change for CC-855 that eases the transition from/to Fargate.

Resolves:
https://companieshouse.atlassian.net/browse/CC-855